### PR TITLE
Use AnyCPU as the target platform

### DIFF
--- a/ApiIntersect.sln
+++ b/ApiIntersect.sln
@@ -1,18 +1,22 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 15
+VisualStudioVersion = 15.0.26214.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiIntersect", "ApiIntersect\ApiIntersect.csproj", "{CD767D93-6C99-4D6A-A303-3C139A73400E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|AnyCPU = Debug|AnyCPU
+		Release|AnyCPU = Release|AnyCPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|x86.ActiveCfg = Debug|x86
-		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|x86.Build.0 = Debug|x86
-		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|x86.ActiveCfg = Release|x86
-		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|x86.Build.0 = Release|x86
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{CD767D93-6C99-4D6A-A303-3C139A73400E}.Release|AnyCPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/ApiIntersect/ApiIntersect.csproj
+++ b/ApiIntersect/ApiIntersect.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\packages\NuGet.Build.Packaging.0.1.173\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.1.173\build\NuGet.Build.Packaging.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CD767D93-6C99-4D6A-A303-3C139A73400E}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>AppleIntersector</RootNamespace>
@@ -12,7 +12,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -21,9 +21,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ConsolePause>false</ConsolePause>
-    <IntermediateOutputPath>obj\x86\Debug</IntermediateOutputPath>
+    <IntermediateOutputPath>obj\Debug</IntermediateOutputPath>
     <ExternalConsole>false</ExternalConsole>
     <Commandlineparameters>-i /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/Xamarin.iOS.dll -i /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.WatchOS/Xamarin.WatchOS.dll  -i /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/Xamarin.Mac/Xamarin.Mac.dll -i /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.TVOS/Xamarin.TVOS.dll -b ObjCRuntime.Constants -b ObjCRuntime.BlockProxyAttribute -b ObjCRuntime.DesignatedInitializerAttribute -f /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks/.NETPortable/v4.5/Profile/Profile7 -vvv</Commandlineparameters>
     <RunWithWarnings>true</RunWithWarnings>
@@ -34,14 +34,14 @@
     <NoStdLib>false</NoStdLib>
     <WarningsNotAsErrors />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>
-    <PlatformTarget>x86</PlatformTarget>
-    <IntermediateOutputPath>obj\x86\Release</IntermediateOutputPath>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <IntermediateOutputPath>obj\Release</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil">


### PR DESCRIPTION
This avoids an annoying NuGet bug (https://github.com/NuGet/Home/issues/4316)
that prevents restore from `msbuild /t:restore`