### PR TITLE
Added error handling with empty intersections

### DIFF
--- a/ApiIntersect/Program.cs
+++ b/ApiIntersect/Program.cs
@@ -821,6 +821,14 @@ namespace ApiIntersect
 
 		static void DumpTypes (List<TypeDefinition> types, string baseDir)
 		{
+			if (types == null || !types.Any ()) {
+				WriteWarning (
+					"Sorry, the intersection between types in the different assemblies is empty. " +
+					"May it be possible you were trying Bait-and-switch on types inheriting on dependencies? " +
+					"In such case that technique won't work for this scenario, please disable it.");
+				return;
+			}
+
 			var module = types.First ().Module;
 
 			var context = new DecompilerContext (module);


### PR DESCRIPTION
Hi guys,

I misunderstood how Bait-and-switch works and got once and again an empty sequence exception –Google-ing for such also happens to some people as well.

Debugging it I found out the issue and fixed the error it-self, plus adding some info which may be useful to help others figure out what was happening.

Feel free to tell me even if the warning message could be improved.

Thanks in advance,

Marcos