### PR TITLE
Support ignoring assembly resolution failures

### DIFF
--- a/ApiIntersect/FrameworkAssemblyResolver.cs
+++ b/ApiIntersect/FrameworkAssemblyResolver.cs
@@ -30,6 +30,8 @@ namespace ApiIntersect
 						AddAssembly (asm);
 		}
 
+		public bool ThrowOnResolveFailure { get; set; } = true;
+
 		public AssemblyDefinition Resolve (string fullName)
 		{
 			return Resolve (AssemblyNameReference.Parse (fullName));
@@ -49,7 +51,11 @@ namespace ApiIntersect
 		{
 			AssemblyDefinition asm;
 			if (!assemblies.TryGetValue (name, out asm)) {
-				throw new Exception ($"Could not resolve {name}");
+				if (ThrowOnResolveFailure) {
+					throw new Exception ($"Could not resolve {name}");
+				} else {
+					Console.Error.WriteLine ($"WARNING: Could not resolve {name}");
+				}
 			}
 			return asm;
 		}

--- a/ApiIntersect/Program.cs
+++ b/ApiIntersect/Program.cs
@@ -49,6 +49,7 @@ namespace ApiIntersect
 		static bool stripSerializableAttribute = true;
 		static bool redirectInteropServices = true;
 		static bool keepInternalCtors = false;
+		static bool ignoreAssemblyResolutionFailures;
 
 		static int verbosity = 0;
 
@@ -76,7 +77,8 @@ namespace ApiIntersect
 				{ "o|output=", "Path to output the generated code", o => outputPath = o },
 				{ "h|help", "Show help", _ => printHelp = true },
 				{ "v|verbose", "Increase output verbosity", _ => verbosity++ },
-				{ "r|refPath=", "Directory to resolve assembly references", r => refPaths.Add (r) }
+				{ "r|refPath=", "Directory to resolve assembly references", r => refPaths.Add (r) },
+				{ "iua|ignore-unresolved-assemblies", "Ignore failure to resolve an assembly", _ => ignoreAssemblyResolutionFailures = true }
 			};
 
 			try {
@@ -110,7 +112,9 @@ namespace ApiIntersect
 					Console.Error.WriteLine ($"ERROR: no framework found at {frameworkPath}");
 					return 1;
 				}
-				readerParameters.AssemblyResolver = new FrameworkAssemblyResolver (frameworkPath, refPaths);
+				readerParameters.AssemblyResolver = new FrameworkAssemblyResolver (frameworkPath, refPaths) {
+					ThrowOnResolveFailure = !ignoreAssemblyResolutionFailures
+				};
 				readerParameters.MetadataResolver = new HackMetadataResolver (readerParameters.AssemblyResolver);
 
 				//PCLs don't have System.SerializableAttribute


### PR DESCRIPTION
Added a new command line argument -ignore-unresolved-assemblies
or -iua which is false by default. This can be set so that
if an assembly cannot be resolved an exception is not thrown and
instead a warning is logged. For example, an assembly may
referenced MonoAndroid but you may not be interested in the
intersection with any Android types so instead of having the
ApiIntersect tool fail when it fails to resolve MonoAndroid you
can optionally have it ignore this resolution failure and
continue processing.